### PR TITLE
[12.0][FIX/MIG] stock_cycle_count: fix zero confirmation rules.

### DIFF
--- a/stock_cycle_count/models/stock_location.py
+++ b/stock_cycle_count/models/stock_location.py
@@ -57,7 +57,10 @@ class StockLocation(models.Model):
     @api.multi
     def _get_zero_confirmation_domain(self):
         self.ensure_one()
-        domain = [('location_id', '=', self.id)]
+        domain = [
+            ('location_id', '=', self.id),
+            ('quantity', '>', 0.0),
+        ]
         return domain
 
     @api.multi


### PR DESCRIPTION
Now zero-qty quants are not removed straight away but by a cron job.
Therefore, we have to also check that the quants are not zero-qty ones.

cc @bodedra